### PR TITLE
Added Queue Command, Volume Setting etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,16 +123,3 @@ bins
 *.zip
 
 .vscode
-node/CHANGELOG.md
-node/corepack
-node/corepack.cmd
-node/install_tools.bat
-node/LICENSE
-node/node_etw_provider.man
-node/node.exe
-node/nodevars.bat
-node/npm
-node/npm.cmd
-node/npx
-node/npx.cmd
-node/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,16 @@ bins
 *.zip
 
 .vscode
+node/CHANGELOG.md
+node/corepack
+node/corepack.cmd
+node/install_tools.bat
+node/LICENSE
+node/node_etw_provider.man
+node/node.exe
+node/nodevars.bat
+node/npm
+node/npm.cmd
+node/npx
+node/npx.cmd
+node/README.md

--- a/index.js
+++ b/index.js
@@ -224,7 +224,7 @@ let printQueue = async (channel) => {
 
             // using 'every' to loop instead of 'foreach' allows us to break out of a loop like this
             // so we can keep it 
-            if (queueDepthIndex <= 1) {
+            if (queueDepthIndex <= 0) {
                 return false;
             }
             else {

--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ let handleQueue = async (channel) => {
             await refreshAccessToken();
             await printQueue(channel);
         } else {
-            client.say(chatbotConfig.channel_name, `Seems like no music is playing right now (${error?.response?.data?.error?.status})`);
+            client.say(chatbotConfig.channel_name, `Seems like no music is playing right now`);
         }
     }
 }

--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ let handleQueue = async (channel) => {
             await refreshAccessToken();
             await printQueue(channel);
         } else {
-            client.say(chatbotConfig.channel_name, 'Seems like no music is playing right now');
+            client.say(chatbotConfig.channel_name, `Seems like no music is playing right now (${error?.response?.data?.error?.status})`);
         }
     }
 }

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const { username } = require('tmi.js/lib/utils');
 
 let spotifyRefreshToken = '';
 let spotifyAccessToken = '';
+let voteskipTimeout;
 
 const client_id = process.env.SPOTIFY_CLIENT_ID;
 const client_secret = process.env.SPOTIFY_CLIENT_SECRET;
@@ -42,7 +43,7 @@ const expressPort = chatbotConfig.express_port;
 const cooldownDuration = chatbotConfig.cooldown_duration * 1000;
 const usersOnCooldown = new Set();
 const usersHaveSkipped = new Set();
-const voteskipTimeout;
+
 
 // CHECK FOR UPDATES
 axios.get("https://api.github.com/repos/KumoKairo/Spotify-Twitch-Song-Requests/releases/latest")
@@ -193,7 +194,7 @@ let handleQueue = async (channel) => {
 let handleVoteSkip = async (channel, username) => {
 
     if (!usersHaveSkipped.has(username)) {
-        startOrProgressVoteskip();
+        startOrProgressVoteskip(channel);
 
         usersHaveSkipped.add(username);
         console.log(`${username} voted to skip the current song (${usersHaveSkipped.size}/${chatbotConfig.required_vote_skip})!`);
@@ -497,15 +498,15 @@ function setupYamlConfigs () {
     return fileConfig;
 }
 
-function startOrProgressVoteskip() {
+function startOrProgressVoteskip(channel) {
     if (usersHaveSkipped.size > 0) {
         clearTimeout(voteskipTimeout);
     }
 
-    voteskipTimeout = setTimeout(resetVoteskip, chatbotConfig.voteskip_timeout * 1000);
+    voteskipTimeout = setTimeout(function() {resetVoteskip(channel)}, chatbotConfig.voteskip_timeout * 1000);
 }
 
-function resetVoteskip() {
+function resetVoteskip(channel) {
     client.say(channel, `Voteskip has timed out... No song will be skipped at this time! catJAM`);
     usersHaveSkipped.clear();
 }

--- a/index.js
+++ b/index.js
@@ -212,15 +212,27 @@ let printQueue = async (channel) => {
 	else {
 		let songIndex = 1;
 		let concatenatedQueue = '';
+        let queueDepthIndex = chatbotConfig.queue_display_depth;
 
-		res.data.queue?.forEach((qItem) => {
-			let trackName = qItem.name;
-			let artists = qItem.artists.map(artist => artist.name).join(', '); 
-            concatenatedQueue = concatenatedQueue.concat(concatenatedQueue, ` ${songIndex}) ${artists} - ${trackName}`);
-			songIndex++;
-		})
+        res.data.queue?.every(qItem => {
+            let trackName = qItem.name;
+            let artists = qItem.artists[0];
+            concatQueue += `• ${songIndex}) ${artists} - ${trackName} `;
+
+            queueDepthIndex--;
+            songIndex++;
+
+            // using 'every' to loop instead of 'foreach' allows us to break out of a loop like this
+            // so we can keep it 
+            if (queueDepthIndex <= 1) {
+                return false;
+            }
+            else {
+                return true;
+            }
+        })
 		
-		client.say(channel, `▶️ Current queue:${concatenatedQueue}`);
+        client.say(channel, `▶️ Next ${chatbotConfig.queue_display_depth} songs: ${concatenatedQueue}`);
 	}	
 }
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ const open = require('open');
 const Twitch = require('./twitchcontroller');
 
 const pack = require('./package.json');
-const { username } = require('tmi.js/lib/utils');
 
 let spotifyRefreshToken = '';
 let spotifyAccessToken = '';

--- a/index.js
+++ b/index.js
@@ -192,13 +192,13 @@ let handleQueue = async (channel) => {
 let handleVoteSkip = async (channel, username) => {
     if(!usersHaveSkipped.has(username)) {
         usersHaveSkipped.add(username);
-        console.log(`${username} voted to skip the song`);
-        client.say(channel, `${username} voted to skip the song`);
+        console.log(`${username} voted to skip the current song (${usersHaveSkipped.size}/${chatbotConfig.required_vote_skip})!`);
+        client.say(channel, `${username} voted to skip the current song (${usersHaveSkipped.size}/${chatbotConfig.required_vote_skip})!`);
     }
     if (usersHaveSkipped.size >= chatbotConfig.required_vote_skip) {
         usersHaveSkipped.clear();
-        console.log(`Chat successfully skipped the song`);
-        client.say(channel, 'chat voted to skip the song');
+        console.log(`Chat has skipped ${currentTrackName(channel)} (${chatbotConfig.required_vote_skip}/${chatbotConfig.required_vote_skip})!`);
+        client.say(channel, `Chat has skipped ${currentTrackName(channel)} (${chatbotConfig.required_vote_skip}/${chatbotConfig.required_vote_skip})!`);
         let spotifyHeaders = getSpotifyHeaders();
         res = await axios.post('https://api.spotify.com/v1/me/player/next', {}, { headers: spotifyHeaders }); 
     }
@@ -217,6 +217,19 @@ let printTrackName = async (channel) => {
     let trackLink = res.data.item.external_urls.spotify;
     let artists = trackInfo.artists.map(artist => artist.name).join(', ');
     client.say(channel, `▶️ ${artists} - ${trackName} -> ${trackLink}`);
+}
+
+let currentTrackName = async (channel) => {
+    let spotifyHeaders = getSpotifyHeaders();
+
+    let res = await axios.get('https://api.spotify.com/v1/me/player/currently-playing', {
+        headers: spotifyHeaders
+    });
+
+    let trackId = res.data.item.id;
+    let trackInfo = await getTrackInfo(trackId);
+    let trackName = trackInfo.name;
+    return `${trackName}`;
 }
 
 let printQueue = async (channel) => {

--- a/index.js
+++ b/index.js
@@ -397,7 +397,7 @@ let getTrackInfo = async (trackId) => {
     return trackInfo.data;
 }
 
-let addSongToQueue = async (songId, channel, callerUsername) => {
+let addSongToQueue = async (songId, channel, callerUsername, tags) => {
     let spotifyHeaders = getSpotifyHeaders();
 
     let trackInfo = await getTrackInfo(songId);
@@ -408,7 +408,9 @@ let addSongToQueue = async (songId, channel, callerUsername) => {
     let uri = trackInfo.uri;
 
     let duration = trackInfo.duration_ms / 1000;
-    if (duration > chatbotConfig.max_duration) {
+    let eligible = isUserEligible(channel, tags, chatbotConfig.ignore_max_length);
+
+    if (duration > chatbotConfig.max_duration && !eligible) {
         client.say(channel, `${trackName} is too long. The max duration is ${chatbotConfig.max_duration} seconds`);
         return;
     }

--- a/index.js
+++ b/index.js
@@ -211,12 +211,12 @@ let printQueue = async (channel) => {
     }
 	else {
 		let songIndex = 1;
-		let concatenatedQueue = '';
+		let concatQueue = '';
         let queueDepthIndex = chatbotConfig.queue_display_depth;
 
         res.data.queue?.every(qItem => {
             let trackName = qItem.name;
-            let artists = qItem.artists[0];
+            let artists = qItem.artists[0].name;
             concatQueue += `• ${songIndex}) ${artists} - ${trackName} `;
 
             queueDepthIndex--;
@@ -232,7 +232,7 @@ let printQueue = async (channel) => {
             }
         })
 		
-        client.say(channel, `▶️ Next ${chatbotConfig.queue_display_depth} songs: ${concatenatedQueue}`);
+        client.say(channel, `▶️ Next ${chatbotConfig.queue_display_depth} songs: ${concatQueue}`);
 	}	
 }
 

--- a/index.js
+++ b/index.js
@@ -177,8 +177,9 @@ let printTrackName = async (channel) => {
     let trackId = res.data.item.id;
     let trackInfo = await getTrackInfo(trackId);
     let trackName = trackInfo.name;
+    let trackLink = res.data.item.external_urls.spotify;
     let artists = trackInfo.artists.map(artist => artist.name).join(', ');
-    client.say(channel, `${artists} - ${trackName}`);
+    client.say(channel, `▶️ ${artists} - ${trackName} -> ${trackLink}`);
 }
 
 let handleSongRequest = async (channel, username, message) => {

--- a/index.js
+++ b/index.js
@@ -197,8 +197,8 @@ let handleVoteSkip = async (channel, username) => {
     }
     if (usersHaveSkipped.size >= chatbotConfig.required_vote_skip) {
         usersHaveSkipped.clear();
-        console.log(`Chat has skipped ${currentTrackName(channel)} (${chatbotConfig.required_vote_skip}/${chatbotConfig.required_vote_skip})!`);
-        client.say(channel, `Chat has skipped ${currentTrackName(channel)} (${chatbotConfig.required_vote_skip}/${chatbotConfig.required_vote_skip})!`);
+        console.log(`Chat has skipped ${await currentTrackName(channel)} (${chatbotConfig.required_vote_skip}/${chatbotConfig.required_vote_skip})!`);
+        client.say(channel, `Chat has skipped ${await currentTrackName(channel)} (${chatbotConfig.required_vote_skip}/${chatbotConfig.required_vote_skip})!`);
         let spotifyHeaders = getSpotifyHeaders();
         res = await axios.post('https://api.spotify.com/v1/me/player/next', {}, { headers: spotifyHeaders }); 
     }
@@ -229,7 +229,7 @@ let currentTrackName = async (channel) => {
     let trackId = res.data.item.id;
     let trackInfo = await getTrackInfo(trackId);
     let trackName = trackInfo.name;
-    return `${trackName}`;
+    return trackName;
 }
 
 let printQueue = async (channel) => {

--- a/index.js
+++ b/index.js
@@ -209,18 +209,19 @@ let printQueue = async (channel) => {
     if (!res.data?.currently_playing || !res.data?.queue){
         client.say(channel, 'Nothing in the queue.')
     }
-	
-	let songIndex = 1;
-	let concatenatedQueue = '';
+	else {
+		let songIndex = 1;
+		let concatenatedQueue = '';
 
-    res.data.queue?.forEach((qItem) => {
-        let trackName = qItem.name;
-        let artists = qItem.artists.map(artist => artist.name).join(', '); 
-		concatenatedQueue = concatenatedQueue.concat(concatenatedQueue, ' ${songIndex}) ${artists} - ${trackName}');
-		songIndex++;
-    })
-	
-	client.say(channel, `▶️ Current queue:${concatenatedQueue}`);
+		res.data.queue?.forEach((qItem) => {
+			let trackName = qItem.name;
+			let artists = qItem.artists.map(artist => artist.name).join(', '); 
+            concatenatedQueue = concatenatedQueue.concat(concatenatedQueue, ` ${songIndex}) ${artists} - ${trackName}`);
+			songIndex++;
+		})
+		
+		client.say(channel, `▶️ Current queue:${concatenatedQueue}`);
+	}	
 }
 
 let handleSongRequest = async (channel, username, message) => {

--- a/index.js
+++ b/index.js
@@ -100,9 +100,9 @@ client.on('message', async (channel, tags, message, self) => {
     } else if (chatbotConfig.allow_volume_set && messageToLower.split(" ")[0] == '!volume') {
         let args = messageToLower.split(" ")[1];
             if (!args) {
-                await handleGetVolume(channel, tags[displayNameTag]);
+                await handleGetVolume(channel, tags);
             } else {
-                await handleSetVolume(channel, tags[displayNameTag], args);
+                await handleSetVolume(channel, tags, args);
             }
     } 
     else if (messageToLower === chatbotConfig.skip_alias) {
@@ -453,7 +453,7 @@ function getSpotifyHeaders() {
 let app = express();
 
 app.get('/login', (req, res) => {
-    const scope = 'user-modify-playback-state user-read-playback-state user-read-currently-playing user-modify-playback-state user-read-playback-state';
+    const scope = 'user-modify-playback-state user-read-playback-state user-read-currently-playing';
     const authParams = new URLSearchParams();
     authParams.append('response_type', 'code');
     authParams.append('client_id', client_id);
@@ -587,7 +587,7 @@ async function handleSkipSong(channel, tags) {
             client.say(channel, `${tags[displayNameTag]} skipped ${await getCurrentTrackName(channel)}!`);
             console.log(`${tags[displayNameTag]} skipped ${await getCurrentTrackName(channel)}!`);
             let spotifyHeaders = getSpotifyHeaders();
-            res = await axios.post('https://api.spotify.com/v1/me/player/next', {}, { headers: spotifyHeaders });
+            res = await axios.post('https://api.spotify.com/v1/me/player/next', null, { headers: spotifyHeaders });
         }
     } catch (error) {
         console.log(error);
@@ -603,7 +603,7 @@ async function handleGetVolume(channel, tags) {
 
         if(eligible) {
             let spotifyHeaders = getSpotifyHeaders();
-            res = await axios.get('https://api.spotify.com/v1/me/player', {}, { headers: spotifyHeaders });
+            res = await axios.get('https://api.spotify.com/v1/me/player', { headers: spotifyHeaders });
 
             let currVolume = res.data.device.volume_percent;
             console.log(`${tags[displayNameTag]}, the current volume is ${currVolume.toString()}!`);
@@ -635,8 +635,8 @@ async function handleSetVolume(channel, tags, arg) {
             }
 
             let spotifyHeaders = getSpotifyHeaders();
-
-            res = await axios.post('https://api.spotify.com/v1/me/player/volume', {number}, { headers: spotifyHeaders });
+            //courtesy of greav
+            res = await axios.put('https://api.spotify.com/v1/me/player/volume', null, { headers: spotifyHeaders, params:{volume_percent: number} });
 
             console.log(`${tags[displayNameTag]} has set the current volume to ${number.toString()}!`);
             client.say(channel, `${tags[displayNameTag]} has set the current volume to ${number.toString()}!`);

--- a/index.js
+++ b/index.js
@@ -390,7 +390,7 @@ function getSpotifyHeaders() {
 let app = express();
 
 app.get('/login', (req, res) => {
-    const scope = 'user-modify-playback-state user-read-currently-playing';
+    const scope = 'user-modify-playback-state user-read-playback-state user-read-currently-playing';
     const authParams = new URLSearchParams();
     authParams.append('response_type', 'code');
     authParams.append('client_id', client_id);

--- a/spotipack_config.yaml
+++ b/spotipack_config.yaml
@@ -21,6 +21,7 @@ use_song_command: TRUE # add !song command that displays currently playing song.
 use_queue_command: TRUE # add !queue command that displays songs currently in the queue. FALSE if you don't want it
 queue_display_depth: 5 # limits the amount of songs that are displayed when a user types !queue. - default is 5
 minimum_requred_bits: 1 # works if usage mode is set to "bits"
+required_vote_skip: 2 # sets threshold for number of votes required to skip a song.
 
 ## SKIP STUFF ##
 skip_alias: "!skip" # alias for the "Skip Song" command

--- a/spotipack_config.yaml
+++ b/spotipack_config.yaml
@@ -21,7 +21,9 @@ use_song_command: TRUE # add !song command that displays currently playing song.
 use_queue_command: TRUE # add !queue command that displays songs currently in the queue. FALSE if you don't want it
 queue_display_depth: 5 # limits the amount of songs that are displayed when a user types !queue. - default is 5
 minimum_requred_bits: 1 # works if usage mode is set to "bits"
-required_vote_skip: 2 # sets threshold for number of votes required to skip a song.
+allow_vote_skip: TRUE # allow users without super-privileges to vote on skipping the song. FALSE if you don't want it
+required_vote_skip: 2 # sets required number of votes to skip a song, if allow_vote_skip is 
+voteskip_timeout: 17 # waits for a number seconds between each user skipping, or cancels the skipvote otherwise. Default is a 17 because 2 people couldn't agree what was too long or too short.
 
 ## SKIP STUFF ##
 skip_alias: "!skip" # alias for the "Skip Song" command

--- a/spotipack_config.yaml
+++ b/spotipack_config.yaml
@@ -33,6 +33,7 @@ voteskip_timeout: 17 # waits for a number seconds between each user skipping, or
 ## MISC STUFF ##
 allow_volume_set: TRUE # allow users with special privileges (set below) to set the volume remotely
 volume_set_level: ["streamer", "mod"] # ["streamer", "mod", "vip", "everyone"]. Remove /add one or several for different user levels. Don't forget commas between options
+ignore_max_length: ["streamer", "mod"] # ["streamer", "mod", "vip", "everyone"]. Remove /add one or several for different user levels. Don't forget commas between options
 
 ## COMMAND COOLDOWN ##
 use_cooldown: FALSE # TRUE or FALSE to enable or disable command cooldown

--- a/spotipack_config.yaml
+++ b/spotipack_config.yaml
@@ -21,13 +21,18 @@ use_song_command: TRUE # add !song command that displays currently playing song.
 use_queue_command: TRUE # add !queue command that displays songs currently in the queue. FALSE if you don't want it
 queue_display_depth: 5 # limits the amount of songs that are displayed when a user types !queue. - default is 5
 minimum_requred_bits: 1 # works if usage mode is set to "bits"
-allow_vote_skip: TRUE # allow users without super-privileges to vote on skipping the song. FALSE if you don't want it
-required_vote_skip: 2 # sets required number of votes to skip a song, if allow_vote_skip is 
-voteskip_timeout: 17 # waits for a number seconds between each user skipping, or cancels the skipvote otherwise. Default is a 17 because 2 people couldn't agree what was too long or too short.
 
 ## SKIP STUFF ##
 skip_alias: "!skip" # alias for the "Skip Song" command
 skip_user_level: ["streamer", "mod"] # ["streamer", "mod", "vip", "everyone"]. Remove /add one or several for different user levels. Don't forget commas between options
+
+allow_vote_skip: TRUE # allow users without special privileges to vote on skipping the song. FALSE if you don't want it
+required_vote_skip: 2 # sets required number of votes to skip a song, if allow_vote_skip is TRUE
+voteskip_timeout: 17 # waits for a number seconds between each user skipping, or cancels the skipvote otherwise. Default is a 17 because 2 people couldn't agree what was too long or too short.
+
+## MISC STUFF ##
+allow_volume_set: TRUE # allow users with special privileges (set below) to set the volume remotely
+volume_set_level: ["streamer", "mod"] # ["streamer", "mod", "vip", "everyone"]. Remove /add one or several for different user levels. Don't forget commas between options
 
 ## COMMAND COOLDOWN ##
 use_cooldown: FALSE # TRUE or FALSE to enable or disable command cooldown

--- a/spotipack_config.yaml
+++ b/spotipack_config.yaml
@@ -19,6 +19,7 @@ command_alias: ["!songrequest", "!sr"] # ["a", "b", ...] all valid aliases to re
 command_user_level: ["everyone"] # ["streamer", "mod", "vip", "sub", "everyone"]. Remove /add one or several for different user levels. Don't forget commas between options
 use_song_command: TRUE # add !song command that displays currently playing song. FALSE if you don't want it
 use_queue_command: TRUE # add !queue command that displays songs currently in the queue. FALSE if you don't want it
+queue_display_depth: 5 # limits the amount of songs that are displayed when a user types !queue. - default is 5
 minimum_requred_bits: 1 # works if usage mode is set to "bits"
 
 ## SKIP STUFF ##

--- a/spotipack_config.yaml
+++ b/spotipack_config.yaml
@@ -18,6 +18,7 @@ usage_type: "command" # can be either "channel_points", "command" or "bits"
 command_alias: ["!songrequest", "!sr"] # ["a", "b", ...] all valid aliases to request songs if usage mode is "command"
 command_user_level: ["everyone"] # ["streamer", "mod", "vip", "sub", "everyone"]. Remove /add one or several for different user levels. Don't forget commas between options
 use_song_command: TRUE # add !song command that displays currently playing song. FALSE if you don't want it
+use_queue_command: TRUE # add !queue command that displays songs currently in the queue. FALSE if you don't want it
 minimum_requred_bits: 1 # works if usage mode is set to "bits"
 
 ## SKIP STUFF ##


### PR DESCRIPTION
Added Following functionality: 

Queue Command
- Configurable Queue depth to prevent returning entire "Next From" section.
Volume Setting
- Reuses eligibility functionality to allow privileged users to set volume via command
- if no parameter provided returns current volume
Vote Skip
- Added Vote Skip command to allow chatters to collectively skip a song.
- configurable threshold for vote skip.
- Configurable vote skip timeout that resets after each successful vote to skip.
Ignore Max Song Length
- Reuses eligibility functionality to allow privileged users to be exempt from max song length.