### PR TITLE
Add a limit on queue length

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,13 +11,12 @@ const open = require('open');
 const Twitch = require('./twitchcontroller');
 
 const pack = require('./package.json');
-const {channel} = require("tmi.js/lib/utils");
 
 let spotifyRefreshToken = '';
 let spotifyAccessToken = '';
 let voteskipTimeout;
 let queueLength = 0;
-let lastQueueLengthCheck = Date.now();
+let lastQueueLengthCheck= Date.now();
 
 const client_id = process.env.SPOTIFY_CLIENT_ID;
 const client_secret = process.env.SPOTIFY_CLIENT_SECRET;
@@ -315,7 +314,6 @@ let fitsInQueue = async (channel, tags, rolesArray) => {
     queueLength = res.data?.queue?.length ? res.data.queue.length : 0
     return queueLength < chatbotConfig.max_queue_length;
 }
-
 
 let handleSongRequest = async (channel, username, message, tags) => {
     let validatedSongId = await validateSongRequest(message, channel);

--- a/spotipack_config.yaml
+++ b/spotipack_config.yaml
@@ -43,6 +43,12 @@ cooldown_duration: 60 # How long a user has to wait in between song requests in 
 ## BLOCKED TRACKS ##
 blocked_tracks: [""]
 
+## QUEUE LENGTH ##
+use_queue_limit: FALSE # allows you to set a limit on the amount of songs that can be queued
+max_queue_length: 10 # The maximum amount of songs that can be in the queue
+queue_cooldown_check: 60 # How long between checks of the queue length, helps reduce API calls
+ignore_max_queue_length: ["streamer", "mod"] # ["streamer", "mod", "vip", "everyone"]. Remove /add one or several for different user levels. Don't forget commas between options
+
 # List of ENV variables required at the start:
 # SPOTIFY_CLIENT_ID
 # SPOTIFY_CLIENT_SECRET


### PR DESCRIPTION
Request: To have the ability to set a limit on the number of songs that can be queued.

Justification/Reason for request: When queues become too long, users requesting new songs might never hear them before they have to leave the stream. This feature would allow streamers to set a limit that's right for their community, and allow their viewers to queue songs that they'll get to listen to in a reasonable time frame. This feature should be able to be toggled so it won't affect those who do not wish to have a queue limit.

*Please let me know if there's interest in accepting this pull request, so I know it's worth the time to set up everything needed to fully test this feature.*